### PR TITLE
Install does not support -d on darwin platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,11 @@ install: $(NAME)
 		install -M 644 -f $(MANDIR)/man1 doc/$(NAME).1; \
 		install -M 600 -c $(SYSCONFDIR) doc/$(NAME).conf; \
 	elif [ "`uname -s`" = "Darwin" ]; then \
-		install -d -m 755 -s $(NAME) $(BINDIR)/$(NAME); \
-		install -d -m 644 doc/$(NAME).1 $(MANDIR)/man1/$(NAME).1; \
+		mkdir -p $(SYSCONFDIR) $(BINDIR) $(MANDIR)/man1; \
+		install -m 755 -s $(NAME) $(BINDIR)/$(NAME); \
+		install -m 644 doc/$(NAME).1 $(MANDIR)/man1/$(NAME).1; \
 		[ -f $(SYSCONFDIR)/$(NAME).conf -o -z "$(SYSCONFDIR)" ] \
-			|| install -d -m 600 doc/$(NAME).conf $(SYSCONFDIR)/$(NAME).conf; \
+			|| install -m 600 doc/$(NAME).conf $(SYSCONFDIR)/$(NAME).conf; \
 	else \
 		install -D -m 755 -s $(NAME) $(BINDIR)/$(NAME); \
 		install -D -m 644 doc/$(NAME).1 $(MANDIR)/man1/$(NAME).1; \


### PR DESCRIPTION
Make install on Mac fails as -d is not supported with the install command on MacOS